### PR TITLE
[220902]  HTTP 활용하기

### DIFF
--- a/cache/src/main/java/com/example/cachecontrol/CacheWebConfig.java
+++ b/cache/src/main/java/com/example/cachecontrol/CacheWebConfig.java
@@ -9,5 +9,6 @@ public class CacheWebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(new NoCacheInterceptor());
     }
 }

--- a/cache/src/main/java/com/example/cachecontrol/NoCacheInterceptor.java
+++ b/cache/src/main/java/com/example/cachecontrol/NoCacheInterceptor.java
@@ -1,7 +1,9 @@
 package com.example.cachecontrol;
 
+import com.google.common.net.HttpHeaders;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.CacheControl;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 public class NoCacheInterceptor implements HandlerInterceptor {
@@ -9,7 +11,7 @@ public class NoCacheInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response,
                              final Object handler) {
-        response.setHeader("Cache-Control", "no-cache, private");
+        response.addHeader(HttpHeaders.CACHE_CONTROL, CacheControl.noCache().cachePrivate().getHeaderValue());
         return true;
     }
 }

--- a/cache/src/main/java/com/example/cachecontrol/NoCacheInterceptor.java
+++ b/cache/src/main/java/com/example/cachecontrol/NoCacheInterceptor.java
@@ -1,0 +1,15 @@
+package com.example.cachecontrol;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class NoCacheInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response,
+                             final Object handler) {
+        response.setHeader("Cache-Control", "no-cache, private");
+        return true;
+    }
+}

--- a/cache/src/main/java/com/example/etag/EtagFilterConfiguration.java
+++ b/cache/src/main/java/com/example/etag/EtagFilterConfiguration.java
@@ -12,7 +12,7 @@ public class EtagFilterConfiguration {
     public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
         FilterRegistrationBean<ShallowEtagHeaderFilter> filterRegistrationBean = new FilterRegistrationBean<>(
                 new ShallowEtagHeaderFilter());
-        filterRegistrationBean.addUrlPatterns("/etag");
+        filterRegistrationBean.addUrlPatterns("/etag", "/resources/*");
         return filterRegistrationBean;
     }
 }

--- a/cache/src/main/java/com/example/etag/EtagFilterConfiguration.java
+++ b/cache/src/main/java/com/example/etag/EtagFilterConfiguration.java
@@ -1,12 +1,18 @@
 package com.example.etag;
 
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
 
 @Configuration
 public class EtagFilterConfiguration {
 
-//    @Bean
-//    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
-//        return null;
-//    }
+    @Bean
+    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
+        FilterRegistrationBean<ShallowEtagHeaderFilter> filterRegistrationBean = new FilterRegistrationBean<>(
+                new ShallowEtagHeaderFilter());
+        filterRegistrationBean.addUrlPatterns("/etag");
+        return filterRegistrationBean;
+    }
 }

--- a/cache/src/main/java/com/example/version/CacheBustingWebConfig.java
+++ b/cache/src/main/java/com/example/version/CacheBustingWebConfig.java
@@ -1,7 +1,9 @@
 package com.example.version;
 
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -20,6 +22,7 @@ public class CacheBustingWebConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(final ResourceHandlerRegistry registry) {
         registry.addResourceHandler(PREFIX_STATIC_RESOURCES + "/" + version.getVersion() + "/**")
+                .setCacheControl(CacheControl.maxAge(Duration.ofDays(365)).cachePublic())
                 .addResourceLocations("classpath:/static/");
     }
 }

--- a/cache/src/main/resources/application.yml
+++ b/cache/src/main/resources/application.yml
@@ -1,2 +1,7 @@
 handlebars:
   suffix: .html
+
+server:
+  compression:
+    enabled: true
+    min-response-size: 10


### PR DESCRIPTION
# 0단계 - 휴리스틱 캐싱 제거하기
HTTP 응답 헤더에 Cache-Control가 없어도 웹 브라우저가 휴리스틱 캐싱에 따른 암시적 캐싱을 한다.
의도하지 않은 캐싱을 막기 위해 모든 응답의 헤더에 Cache-Control: no-cache를 명시한다.
또한, 쿠키나 사용자 개인 정보 유출을 막기 위해 private도 추가한다.
모든 응답 헤더의 기본 캐싱을 아래와 같이 설정한다.
GreetingControllerTest 클래스의 testNoCachePrivate() 테스트 메서드를 통과시키면 된다.

```
Cache-Control: no-cache, private

```

### 힌트
CacheWebConfig 클래스에서 Cache-Control 설정을 적용하면 된다.

# 1단계 - HTTP Compression 설정하기
HTTP 응답을 압축하면 웹 사이트의 성능을 높일 수 있다.
스프링 부트 설정을 통해 gzip과 같은 HTTP 압축 알고리즘을 적용시킬 수 있다.
테스트 코드가 통과하는지
gzip이 적용됐는지 테스트 코드가 아닌 웹 브라우저에서 HTTP 응답의 헤더를 직접 확인한다.
GreetingControllerTest 클래스의 testCompression() 테스트 메서드를 통과시키면 된다.

### 힌트
스프링 부트 공식 문서의 [Enable HTTP Response Compression](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto.webserver.enable-response-compression)를 참고해서 적용해본다.
min-response-size는 기본 2KB이기 때문에 작은 크기의 html 파일은 압축하지 않는다. 값을 10으로 설정해준다.

# 2단계 - ETag/If-None-Match 적용하기
ETag와 If-None-Match를 사용하여 HTTP 캐싱을 적용해보자.
Spring mvc에서 ShallowEtagHeaderFilter 클래스를 제공한다.
필터를 사용하여 /etag 경로만 ETag를 적용하자.
GreetingControllerTest 클래스의 testETag() 테스트 메서드를 통과시키면 된다.

### 힌트
EtagFilterConfiguration 클래스에서 ShallowEtagHeaderFilter 필터를 추가한다.

# 3단계 - 캐시 무효화(Cache Busting)
어떤 경우에 HTTP 캐시를 적용하는게 좋을까?
JS, CSS 같은 정적 리소스 파일은 캐싱을 적용하기 좋다.
하지만 자바스크립트와 css는 개발이 진행됨에 따라 자주 변경되고, 자바스크립트와 CSS 리소스 버전이 동기화되지 않으면 화면이 깨진다.
캐시는 URL을 기반으로 리소스를 구분하므로 리소스가 업데이트될 때 URL을 변경하면 손쉽게 JS, CSS 파일의 캐시를 제거할 수 있다.
캐시 무효화는 콘텐츠가 변경될 때 URL을 변경하여 응답을 장기간 캐시하게 만드는 기술이다.
어떻게 적용할까?
정적 리소스 파일의 max-age를 최대치(1년)로 설정한다.
ETag도 적용한다.
JS, CSS 리소스에 변경사항이 생기면 캐시가 제거되도록 url에 버전을 적용하자.
CacheBustingWebConfig 클래스의 addResourceHandlers 메서드의 registry에 리소스 디렉터리에 버전을 추가하고 캐싱을 추가한다.
GreetingControllerTest 클래스의 testCacheBustingOfStaticResources() 테스트 메서드를 통과시키면 된다.