### PR TITLE
[220915] Servlet 활용하기

### DIFF
--- a/servlet/src/main/java/com/example/CharacterEncodingFilter.java
+++ b/servlet/src/main/java/com/example/CharacterEncodingFilter.java
@@ -1,16 +1,21 @@
 package com.example;
 
-import jakarta.servlet.*;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
 import jakarta.servlet.annotation.WebFilter;
-
 import java.io.IOException;
 
 @WebFilter("/*")
 public class CharacterEncodingFilter implements Filter {
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
         request.getServletContext().log("doFilter() 호출");
+        response.setCharacterEncoding("UTF-8");
         chain.doFilter(request, response);
     }
 }

--- a/servlet/src/test/java/com/example/ServletTest.java
+++ b/servlet/src/test/java/com/example/ServletTest.java
@@ -50,6 +50,8 @@ class ServletTest {
 
         // expected를 0이 아닌 올바른 값으로 바꿔보자.
         // 예상한 결과가 나왔는가? 왜 이런 결과가 나왔을까?
-        assertThat(Integer.parseInt(response.body())).isEqualTo(0);
+
+        // 👉 body에 담기는 localCounter 값은 로직이 호출될 때마다 초기화 & 카운트 된다.
+        assertThat(Integer.parseInt(response.body())).isEqualTo(1);
     }
 }

--- a/servlet/src/test/java/com/example/ServletTest.java
+++ b/servlet/src/test/java/com/example/ServletTest.java
@@ -25,7 +25,10 @@ class ServletTest {
 
         // expected를 0이 아닌 올바른 값으로 바꿔보자.
         // 예상한 결과가 나왔는가? 왜 이런 결과가 나왔을까?
-        assertThat(Integer.parseInt(response.body())).isEqualTo(0);
+
+        // 👉 body에 담기는 sharedCounter는 모든 스레드에서 공유되는 값이다.
+        // 서블릿은 서버가 실행해서 끝날때까지 한번만 초기화되고 끝날때까지 재사용된다.
+        assertThat(Integer.parseInt(response.body())).isEqualTo(3);
     }
 
     @Test


### PR DESCRIPTION
# 1단계 - 서블릿 학습 테스트
SharedCounterServlet, LocalCounterServlet 클래스를 열어보고 어떤 차이점이 있는지 확인한다.
ServletTest를 통과시킨다.
init, service, destroy 메서드가 각각 언제 실행되는지 콘솔 로그에서 확인한다.
왜 이런 결과가 나왔는지 다른 크루와 이야기해보자.
직접 톰캣 서버를 띄워보고 싶다면 ServletApplication 클래스의 main 메서드를 실행한다.
웹 브라우저에서 localhost:8080/shared-counter 경로에 접근 가능한지 확인한다.

> 예전 서블릿 책을 보면 서블릿 클래스를 구현하고 xml에 등록하는 내용이 나온다. 
Servlet 3.0부터는 @WebServlet을 사용하면 된다.
필터도 마찬가지로 @WebFilter를 사용한다.

# 2단계 - 필터 학습 테스트
FilterTest를 통과시킨다.
doFilter 메서드는 어느 시점에 실행될까? 콘솔 로그에서 확인한다.
왜 인코딩을 따로 설정해줘야 할까?
[ServletResponse](https://docs.oracle.com/javaee/7/api/javax/servlet/ServletResponse.html)
위 링크에서 character encoding에 대한 설명을 참고하자.