### PR TITLE
[220927] DI 활용하기

### DIFF
--- a/di/src/test/java/nextstep/study/di/stage3/context/DIContainer.java
+++ b/di/src/test/java/nextstep/study/di/stage3/context/DIContainer.java
@@ -1,6 +1,12 @@
 package nextstep.study.di.stage3.context;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * 스프링의 BeanFactory, ApplicationContext에 해당되는 클래스
@@ -10,11 +16,59 @@ class DIContainer {
     private final Set<Object> beans;
 
     public DIContainer(final Set<Class<?>> classes) {
-        this.beans = Set.of();
+        this.beans = createBeans(classes);
+        initializeBeans();
+    }
+
+    private Set<Object> createBeans(final Set<Class<?>> classes) {
+        return classes.stream()
+                .map(this::createInstance)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private Object createInstance(final Class<?> clazz) {
+        try {
+            Constructor<?> constructor = clazz.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
+                 NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void initializeBeans() {
+        for (Object bean : beans) {
+            Field[] fields = bean.getClass().getDeclaredFields();
+            setFields(bean, fields);
+        }
+    }
+
+    private void setFields(final Object bean, final Field[] fields) {
+        for (Field field : fields) {
+            setField(bean, field);
+        }
+    }
+
+    private void setField(final Object bean, final Field field) {
+        try {
+            field.setAccessible(true);
+            Object object = field.get(bean);
+            if (Objects.isNull(object)) {
+                field.set(bean, getBean(field.getType()));
+            }
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @SuppressWarnings("unchecked")
-    public <T> T getBean(final Class<T> aClass) {
-        return null;
+    public <T> T getBean(final Class<T> clazz) {
+        Object instance = beans.stream()
+                .filter(clazz::isInstance)
+                .findAny()
+                .orElseThrow(() -> new NoSuchElementException("해당 클래스 타입의 빈은 존재하지 않습니다. -> " + clazz));
+
+        return (T) instance;
     }
 }

--- a/di/src/test/java/nextstep/study/di/stage3/context/UserService.java
+++ b/di/src/test/java/nextstep/study/di/stage3/context/UserService.java
@@ -6,6 +6,8 @@ class UserService {
 
     private UserDao userDao;
 
+    private UserService() {}
+
     public UserService(final UserDao userDao) {
         this.userDao = userDao;
     }
@@ -14,6 +16,4 @@ class UserService {
         userDao.insert(user);
         return userDao.findById(user.getId());
     }
-
-    private UserService() {}
 }

--- a/di/src/test/java/nextstep/study/di/stage4/annotations/ClassPathScanner.java
+++ b/di/src/test/java/nextstep/study/di/stage4/annotations/ClassPathScanner.java
@@ -1,10 +1,18 @@
 package nextstep.study.di.stage4.annotations;
 
+import java.util.HashSet;
 import java.util.Set;
+import org.reflections.Reflections;
 
 public class ClassPathScanner {
 
     public static Set<Class<?>> getAllClassesInPackage(final String packageName) {
-        return null;
+        Reflections reflections = new Reflections(packageName);
+
+        Set<Class<?>> classes = new HashSet<>();
+        classes.addAll(reflections.getTypesAnnotatedWith(Repository.class));
+        classes.addAll(reflections.getTypesAnnotatedWith(Service.class));
+        
+        return classes;
     }
 }

--- a/di/src/test/java/nextstep/study/di/stage4/annotations/DIContainer.java
+++ b/di/src/test/java/nextstep/study/di/stage4/annotations/DIContainer.java
@@ -40,6 +40,11 @@ class DIContainer {
 
     @SuppressWarnings("unchecked")
     public <T> T getBean(final Class<T> aClass) {
-        return null;
+        Object instance = beans.stream()
+                .filter(aClass::isInstance)
+                .findAny()
+                .orElseThrow(() -> new NoSuchElementException("해당 클래스 타입의 빈은 존재하지 않습니다. -> " + aClass));
+
+        return (T) instance;
     }
 }

--- a/di/src/test/java/nextstep/study/di/stage4/annotations/DIContainer.java
+++ b/di/src/test/java/nextstep/study/di/stage4/annotations/DIContainer.java
@@ -1,6 +1,10 @@
 package nextstep.study.di.stage4.annotations;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * 스프링의 BeanFactory, ApplicationContext에 해당되는 클래스
@@ -9,12 +13,29 @@ class DIContainer {
 
     private final Set<Object> beans;
 
-    public DIContainer(final Set<Class<?>> classes) {
-        this.beans = Set.of();
+    private DIContainer(final Set<Class<?>> classes) {
+        this.beans = createBeans(classes);
+    }
+
+    private Set<Object> createBeans(final Set<Class<?>> classes) {
+        return classes.stream()
+                .map(this::createInstance)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private Object createInstance(final Class<?> clazz) {
+        try {
+            Constructor<?> constructor = clazz.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
+                 NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public static DIContainer createContainerForPackage(final String rootPackageName) {
-        return null;
+        return new DIContainer(ClassPathScanner.getAllClassesInPackage(rootPackageName));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
# 학습 순서
1. DI 컨테이너로 변화하는 과정을 코드로 학습하자.
2. di 모듈의 테스트 코드에 di 패키지가 있다.
3. stage0부터 stage2까지 변화 과정은 강의에서 설명
4. stage3, stage4의 테스트 코드가 정상 동작하도록 DIContainer를 구현한다.

## 3단계
- 생성자 파라미터로 Set<Class<?>>를 전달하자.
- 전달 받은 클래스를 객체로 생성한다.
- 객체의 내부 필드의 타입에 맞는 객체(baen)를 찾아서 대입(assign)한다.
- DI에서 관리하는 객체(bean)를 찾아서 반환한다.

## 4단계
- stage3에서 구현한 기능을 기본적으로 제공한다.
- 생성자 파라미터로 패키지명을 받아서 클래스를 찾는 ClassPathScanner를 구현한다.
- @Service, @Repository가 존재하는 클래스만 객체로 생성한다.
- 객체에서 @Inject를 붙인 필드만 필터하고 타입에 맞는 객체(bean)를 찾아서 대입(assign)한다.
- DI에서 관리하는 객체(bean)를 찾아서 반환한다.