### PR TITLE
[221001] Connection Pool 활용하기

### DIFF
--- a/connectionpool/src/test/java/jdbc/stage0/Stage0Test.java
+++ b/connectionpool/src/test/java/jdbc/stage0/Stage0Test.java
@@ -1,55 +1,46 @@
 package jdbc.stage0;
 
-import org.h2.jdbcx.JdbcDataSource;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.SQLException;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.Test;
 
 class Stage0Test {
 
     private static final String H2_URL = "jdbc:h2:./test";
-    private static final String USER = "sa";
-    private static final String PASSWORD = "";
 
     /**
-     * DriverManager
-     * JDBC 드라이버를 관리하는 가장 기본적인 방법.
-     * 커넥션 풀, 분산 트랜잭션을 지원하지 않아서 잘 사용하지 않는다.
-     *
-     * JDBC 4.0 이전에는 Class.forName 메서드를 사용하여 JDBC 드라이버를 직접 등록해야 했다.
-     * JDBC 4.0 부터 DriverManager가 적절한 JDBC 드라이버를 찾는다.
-     *
-     * Autoloading of JDBC drivers
-     * https://docs.oracle.com/javadb/10.8.3.0/ref/rrefjdbc4_0summary.html
+     * DriverManager JDBC 드라이버를 관리하는 가장 기본적인 방법. 커넥션 풀, 분산 트랜잭션을 지원하지 않아서 잘 사용하지 않는다.
+     * <p>
+     * JDBC 4.0 이전에는 Class.forName 메서드를 사용하여 JDBC 드라이버를 직접 등록해야 했다. JDBC 4.0 부터 DriverManager가 적절한 JDBC 드라이버를 찾는다.
+     * <p>
+     * Autoloading of JDBC drivers https://docs.oracle.com/javadb/10.8.3.0/ref/rrefjdbc4_0summary.html
      */
     @Test
     void driverManager() throws SQLException {
         // Class.forName("org.h2.Driver"); // JDBC 4.0 부터 생략 가능
         // DriverManager 클래스를 활용하여 static 변수의 정보를 활용하여 h2 db에 연결한다.
-        try (final Connection connection = null) {
+        try (final Connection connection = DriverManager.getConnection(H2_URL)) {
             assertThat(connection.isValid(1)).isTrue();
         }
     }
 
     /**
-     * DataSource
-     * 데이터베이스, 파일 같은 물리적 데이터 소스에 연결할 때 사용하는 인터페이스.
-     * 구현체는 각 vendor에서 제공한다.
-     * 테스트 코드의 JdbcDataSource 클래스는 h2에서 제공하는 클래스다.
-     *
-     * DirverManager가 아닌 DataSource를 사용하는 이유
-     * - 애플리케이션 코드를 직접 수정하지 않고 properties로 디비 연결을 변경할 수 있다.
-     * - 커넥션 풀링(Connection pooling) 또는 분산 트랜잭션은 DataSource를 통해서 사용 가능하다.
-     *
+     * DataSource 데이터베이스, 파일 같은 물리적 데이터 소스에 연결할 때 사용하는 인터페이스. 구현체는 각 vendor에서 제공한다. 테스트 코드의 JdbcDataSource 클래스는 h2에서
+     * 제공하는 클래스다.
+     * <p>
+     * DirverManager가 아닌 DataSource를 사용하는 이유 - 애플리케이션 코드를 직접 수정하지 않고 properties로 디비 연결을 변경할 수 있다. - 커넥션 풀링(Connection
+     * pooling) 또는 분산 트랜잭션은 DataSource를 통해서 사용 가능하다.
+     * <p>
      * Using a DataSource Object to Make a Connection
      * https://docs.oracle.com/en/java/javase/11/docs/api/java.sql/javax/sql/package-summary.html
      */
     @Test
     void dataSource() throws SQLException {
-        final JdbcDataSource dataSource = null;
+        final JdbcDataSource dataSource = new JdbcDataSource();
 
         try (final var connection = dataSource.getConnection()) {
             assertThat(connection.isValid(1)).isTrue();

--- a/connectionpool/src/test/java/jdbc/stage0/Stage0Test.java
+++ b/connectionpool/src/test/java/jdbc/stage0/Stage0Test.java
@@ -41,6 +41,7 @@ class Stage0Test {
     @Test
     void dataSource() throws SQLException {
         final JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setURL(H2_URL);
 
         try (final var connection = dataSource.getConnection()) {
             assertThat(connection.isValid(1)).isTrue();

--- a/connectionpool/src/test/java/jdbc/stage1/Stage1Test.java
+++ b/connectionpool/src/test/java/jdbc/stage1/Stage1Test.java
@@ -57,6 +57,11 @@ class Stage1Test {
     @Test
     void testHikariCP() {
         final var hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl(H2_URL);
+        hikariConfig.setMaximumPoolSize(5);
+        hikariConfig.addDataSourceProperty("cachePrepStmts", "true");
+        hikariConfig.addDataSourceProperty("prepStmtCacheSize", "250");
+        hikariConfig.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
 
         final var dataSource = new HikariDataSource(hikariConfig);
         final var properties = dataSource.getDataSourceProperties();

--- a/connectionpool/src/test/java/jdbc/stage1/Stage1Test.java
+++ b/connectionpool/src/test/java/jdbc/stage1/Stage1Test.java
@@ -1,34 +1,34 @@
 package jdbc.stage1;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import org.h2.jdbcx.JdbcConnectionPool;
-import org.junit.jupiter.api.Test;
-
 import java.sql.SQLException;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import javax.sql.ConnectionPoolDataSource;
+import org.h2.jdbcx.JdbcConnectionPool;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.Test;
 
 class Stage1Test {
 
     private static final String H2_URL = "jdbc:h2:./test;DB_CLOSE_DELAY=-1";
-    private static final String USER = "sa";
-    private static final String PASSWORD = "";
 
     /**
-     * 커넥션 풀링(Connection Pooling)이란?
-     * DataSource 객체를 통해 미리 커넥션(Connection)을 만들어 두는 것을 의미한다.
-     * 새로운 커넥션을 생성하는 것은 많은 비용이 들기에 미리 커넥션을 만들어두면 성능상 이점이 있다.
-     * 커넥션 풀링에 미리 만들어둔 커넥션은 재사용 가능하다.
-     *
+     * 커넥션 풀링(Connection Pooling)이란? DataSource 객체를 통해 미리 커넥션(Connection)을 만들어 두는 것을 의미한다. 새로운 커넥션을 생성하는 것은 많은 비용이 들기에
+     * 미리 커넥션을 만들어두면 성능상 이점이 있다. 커넥션 풀링에 미리 만들어둔 커넥션은 재사용 가능하다.
+     * <p>
      * h2에서 제공하는 JdbcConnectionPool를 다뤄보며 커넥션 풀에 대한 감을 잡아보자.
-     *
+     * <p>
      * Connection Pooling and Statement Pooling
      * https://docs.oracle.com/en/java/javase/11/docs/api/java.sql/javax/sql/package-summary.html
      */
     @Test
     void testJdbcConnectionPool() throws SQLException {
-        final JdbcConnectionPool jdbcConnectionPool = null;
+        final JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setURL(H2_URL);
+
+        final JdbcConnectionPool jdbcConnectionPool = JdbcConnectionPool.create(dataSource);
 
         assertThat(jdbcConnectionPool.getActiveConnections()).isZero();
         try (final var connection = jdbcConnectionPool.getConnection()) {
@@ -43,20 +43,16 @@ class Stage1Test {
     /**
      * Spring Boot 2.0 부터 HikariCP를 기본 데이터 소스로 채택하고 있다.
      * https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#data.sql.datasource.connection-pool
-     * Supported Connection Pools
-     * We prefer HikariCP for its performance and concurrency. If HikariCP is available, we always choose it.
-     *
-     * HikariCP 공식 문서를 참고하여 HikariCP를 설정해보자.
-     * https://github.com/brettwooldridge/HikariCP#rocket-initialization
-     *
-     * HikariCP 필수 설정
-     * https://github.com/brettwooldridge/HikariCP#essentials
-     *
-     * HikariCP의 pool size는 몇으로 설정하는게 좋을까?
-     * https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
-     *
-     * HikariCP를 사용할 때 적용하면 좋은 MySQL 설정
-     * https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration
+     * Supported Connection Pools We prefer HikariCP for its performance and concurrency. If HikariCP is available, we
+     * always choose it.
+     * <p>
+     * HikariCP 공식 문서를 참고하여 HikariCP를 설정해보자. https://github.com/brettwooldridge/HikariCP#rocket-initialization
+     * <p>
+     * HikariCP 필수 설정 https://github.com/brettwooldridge/HikariCP#essentials
+     * <p>
+     * HikariCP의 pool size는 몇으로 설정하는게 좋을까? https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
+     * <p>
+     * HikariCP를 사용할 때 적용하면 좋은 MySQL 설정 https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration
      */
     @Test
     void testHikariCP() {


### PR DESCRIPTION
# 학습 순서
1. JDBC 드라이버를 사용하여 데이터베이스에 연결하는 방법을 살펴본다.
2. HikariCP가 어떤 것인지 다뤄보고 공식 문서를 읽어본다.
3. MaximumPoolSize를 몇으로 설정하면 좋을지 고민하고 적용한다.

## 0단계 - DataSource 다루기
- 자바에서 제공하는 JDBC 드라이버를 직접 다뤄본다.
- 데이터베이스에 어떻게 연결하는지, 그리고 왜 DataSource를 사용하는지 찾아보자.

## 1단계 - 커넥션 풀링
- 커넥션 풀링이 무엇인지 h2의 JdbcConnectionPool을 직접 다뤄본다.
    - JdbcConnectionPool 클래스가 복잡하지 않으니 직접 분석해봐도 좋다.
- 왜 스프링 부트에서 HikariCP를 사용하는지 찾아본다.
    - [spring boot docs](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#data.sql.datasource.connection-pool)
- 그리고 HikariCP에 어떤 설정을 하면 좋을지 공식 문서를 읽어보자.
    - [HikariCP](https://github.com/brettwooldridge/HikariCP#rocket-initialization)
    - [About Pool Sizing](https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing)
    - [MySQL Configuration](https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration)

## 2단계 - HikariCP 설정하기
- 스프링 부트로 HikariCP를 설정하는 방법을 익힌다.
- 커넥션 풀이 의도한대로 동작하는지 테스트한다.